### PR TITLE
reuseNode as much as possible to avoid deadlocks

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,6 +14,7 @@ pipeline {
         stage('Continuous Integration - PHP') {
             agent {
                 docker { image 'runroom/php8.1-cli' }
+                reuseNode true
             }
 
             steps {
@@ -50,6 +51,7 @@ pipeline {
         stage('Continuous Integration - Node') {
             agent {
                 docker { image 'runroom/node17' }
+                reuseNode true
             }
 
             steps {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,8 +13,10 @@ pipeline {
     stages {
         stage('Continuous Integration - PHP') {
             agent {
-                docker { image 'runroom/php8.1-cli' }
-                reuseNode true
+                docker { 
+                    image 'runroom/php8.1-cli'
+                    reuseNode true
+                }
             }
 
             steps {
@@ -50,8 +52,10 @@ pipeline {
 
         stage('Continuous Integration - Node') {
             agent {
-                docker { image 'runroom/node17' }
-                reuseNode true
+                docker { 
+                    image 'runroom/node17'
+                    reuseNode true
+                }
             }
 
             steps {


### PR DESCRIPTION
If this option is not set, jenkins will try to find a new Node for each agent change. That will end up causing deadlocks if a lot of jobs are executed.

https://issues.jenkins.io/browse/JENKINS-60701

Same as: https://github.com/Runroom/archetype-symfony/pull/2369