### PR TITLE
force lowercase on PROJECT_NAME Makefile variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
 MAKEFILE_PATH := $(abspath $(lastword $(MAKEFILE_LIST)))
-PROJECT_NAME := $(notdir $(patsubst %/,%,$(dir $(MAKEFILE_PATH))))
+PROJECT_NAME := $(shell echo $(notdir $(patsubst %/,%,$(dir $(MAKEFILE_PATH)))) | tr '[:upper:]' '[:lower:]')
 
 include .docker/Makefile


### PR DESCRIPTION
Force lowercase on PROJECT_NAME to avoid the following error when running docker compose:

"Project names must contain only lowercase letters, decimal digits, dashes, and underscores, and must begin with a lowercase letter or decimal digit. If the basename of the project directory or current directory violates this constraint, you must use one of the other mechanisms"