### PR TITLE
Fix issue with jquery validate and integrity hash

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -108,6 +108,7 @@ COPY .docker/app/prod/61_extra.ini /etc/php${PHP_VERSION}/conf.d/
 USER ${USER}
 
 COPY --chown=$UID .env .
+COPY --chown=$UID patches patches
 COPY --chown=$UID composer.json .
 COPY --chown=$UID composer.lock .
 COPY --chown=$UID symfony.lock .

--- a/composer.json
+++ b/composer.json
@@ -116,11 +116,11 @@
             ]
         },
         "patches": {
-            "drupal/core": {
-                "Error running config import \"Call to a member function delete() on null in Drupal\\Core\\Config\\ConfigImporter->checkOp()\" - 3198715": "https://www.drupal.org/files/issues/2021-10-27/error-running-config-import-delete-on-null-3198715-8.patch"
-            },
             "drupal/clientside_validation": {
                 "SubresourceIntegrity": "./patches/0001-Issue-3462084-SubresourceIntegrity.patch"
+            },
+            "drupal/core": {
+                "Error running config import \"Call to a member function delete() on null in Drupal\\Core\\Config\\ConfigImporter->checkOp()\" - 3198715": "https://www.drupal.org/files/issues/2021-10-27/error-running-config-import-delete-on-null-3198715-8.patch"
             }
         }
     },

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     ],
     "homepage": "https://github.com/Runroom/archetype-drupal",
     "require": {
-        "php": "^8.3",
+        "php": "~8.3.0",
         "composer/installers": "2.3.0",
         "cweagans/composer-patches": "1.7.3",
         "drupal/allowed_formats": "3.0.1",
@@ -118,6 +118,9 @@
         "patches": {
             "drupal/core": {
                 "Error running config import \"Call to a member function delete() on null in Drupal\\Core\\Config\\ConfigImporter->checkOp()\" - 3198715": "https://www.drupal.org/files/issues/2021-10-27/error-running-config-import-delete-on-null-3198715-8.patch"
+            },
+            "drupal/clientside_validation": {
+                "SubresourceIntegrity": "./patches/0001-Issue-3462084-SubresourceIntegrity.patch"
             }
         }
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "bbf51699446a178ffe167b18bc8f6557",
+    "content-hash": "43e6cdf3d3b613ec8ab62145a6c906b4",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -13840,7 +13840,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^8.3"
+        "php": "~8.3.0"
     },
     "platform-dev": {},
     "plugin-api-version": "2.6.0"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "43e6cdf3d3b613ec8ab62145a6c906b4",
+    "content-hash": "426b4970a226ded10303c7018015a8d3",
     "packages": [
         {
             "name": "asm89/stack-cors",

--- a/config/base/clientside_validation_jquery.settings.yml
+++ b/config/base/clientside_validation_jquery.settings.yml
@@ -1,6 +1,7 @@
 _core:
   default_config_hash: 3YUV4RQQ4k8drO7uzYJ7lNc5Az0iDAH5YW8KbZVxjeY
 use_cdn: true
-cdn_base_url: 'https://cdn.jsdelivr.net/npm/jquery-validation@1.21.0/dist/'
+cdn_base_url: 'https://cdnjs.cloudflare.com/ajax/libs/jquery-validate/1.21.0/'
 validate_all_ajax_forms: 2
 force_validate_on_blur: 0
+cdn_integrity_attr: sha512-KFHXdr2oObHKI9w4Hv1XPKc898mE4kgYx58oqsc/JqqdLMDI4YjOLzom+EMlW8HFUd0QfjfAvxSL6sEq/a42fQ==

--- a/patches/0001-Issue-3462084-SubresourceIntegrity.patch
+++ b/patches/0001-Issue-3462084-SubresourceIntegrity.patch
@@ -1,0 +1,78 @@
+From 580c1a9d87c0529608d13b3fe517a2cff2952ff8 Mon Sep 17 00:00:00 2001
+From: Sudipta Kumar Pal <offi.sudipta@gmail.com>
+Date: Tue, 15 Oct 2024 08:29:19 +0000
+Subject: [PATCH] Issue #3462084: SubresourceIntegrity
+
+---
+ .../clientside_validation_jquery.module       |  8 ++++++-
+ ...ClientsideValidationjQuerySettingsForm.php | 21 +++++++++++++++++++
+ 2 files changed, 28 insertions(+), 1 deletion(-)
+
+diff --git a/clientside_validation_jquery/clientside_validation_jquery.module b/clientside_validation_jquery/clientside_validation_jquery.module
+index e598033..f42b805 100644
+--- a/clientside_validation_jquery/clientside_validation_jquery.module
++++ b/clientside_validation_jquery/clientside_validation_jquery.module
+@@ -103,7 +103,14 @@ function clientside_validation_jquery_library_info_alter(&$libraries, $extension
+ 
+     // For CDN we use the min versions as Drupal is not going to compress them.
+     unset($libraries['jquery.validate']['js'][$path_in_yml . 'jquery.validate.min.js']);
+-    $libraries['jquery.validate']['js'][$cdn_url . 'jquery.validate.min.js'] = ['type' => 'external'];
++    $libraries['jquery.validate']['js'][$cdn_url . 'jquery.validate.min.js'] = [
++      'type' => 'external',
++      'attributes' => [
++        // It is ok if the integrity attribute is empty.
++        'integrity' => $config->get('cdn_integrity_attr'),
++        'crossorigin' => 'anonymous',
++      ]
++    ];
+ 
+     // Add additional methods js only if required.
+     if (isset($libraries['jquery.validate.additional']['js'][$path_in_yml . 'additional-methods.min.js'])) {
+diff --git a/clientside_validation_jquery/src/Form/ClientsideValidationjQuerySettingsForm.php b/clientside_validation_jquery/src/Form/ClientsideValidationjQuerySettingsForm.php
+index e1464a5..9bbeaa7 100644
+--- a/clientside_validation_jquery/src/Form/ClientsideValidationjQuerySettingsForm.php
++++ b/clientside_validation_jquery/src/Form/ClientsideValidationjQuerySettingsForm.php
+@@ -49,6 +49,16 @@ class ClientsideValidationjQuerySettingsForm extends ConfigFormBase {
+       '#default_value' => $config->get('cdn_base_url'),
+     ];
+ 
++    $form['cdn_integrity_attr'] = [
++      '#type' => 'textfield',
++      '#title' => $this->t('CDN Integrity Attribute'),
++      '#description' => $this->t('Integrity attribute to use. E.g. @attr', [
++        '@attr' => 'sha256-/JqT3SQfawRcv/BIHPThkBvs0OEvtFFmqPF/lYI/Cxo=',
++      ]),
++      '#required' => FALSE,
++      '#default_value' => $config->get('cdn_integrity_attr'),
++    ];
++
+     $form['validate_all_ajax_forms'] = [
+       '#type' => 'select',
+       '#options' => [
+@@ -78,6 +88,7 @@ class ClientsideValidationjQuerySettingsForm extends ConfigFormBase {
+ 
+     $config->set('use_cdn', $form_state->getValue('use_cdn'));
+     $config->set('cdn_base_url', $form_state->getValue('cdn_base_url'));
++    $config->set('cdn_integrity_attr', $form_state->getValue('cdn_integrity_attr'));
+     $config->set('validate_all_ajax_forms', $form_state->getValue('validate_all_ajax_forms'));
+     $config->set('force_validate_on_blur', $form_state->getValue('force_validate_on_blur'));
+ 
+@@ -116,6 +127,16 @@ class ClientsideValidationjQuerySettingsForm extends ConfigFormBase {
+         '@format' => '//cdn.jsdelivr.net/npm/jquery-validation@1.20.0/dist/',
+       ]));
+     }
++
++    // Validate if integrity attribute is valid (empty or according to regex).
++    // https://w3c.github.io/webappsec-subresource-integrity/#grammardef-hash-with-options
++    $integrity_regex = '/(sha256|sha384|sha512)-([A-Za-z0-9+\/]+={0,2}(?=\s|$))( +[!-~]*)?/i';
++    $integrity_attr = $values['cdn_integrity_attr'];
++    if (!empty($integrity_attr) && !preg_match($integrity_regex, $integrity_attr)) {
++      $form_state->setErrorByName('cdn_integrity_attr', $this->t('Integrity attribute seems invalid. Valid format @format.', [
++        '@format' => 'sha256-/JqT3SQfawRcv/BIHPThkBvs0OEvtFFmqPF/lYI/Cxo=',
++      ]));
++    }
+   }
+ 
+ }
+-- 
+2.43.0


### PR DESCRIPTION
## Description

Besides that, I also adapted how we choose php version on composer.json
The patch comes from this issue: https://www.drupal.org/project/clientside_validation/issues/3462084

BUT it CAN'T be applied directly because it does not add the `'crossorigin' => 'anonymous'` attribute and fails when it loads the script, that is why we added the script manually inside the repository.

---

## Checklist
Ensure your pull request meets the following requirements:

- [x] Tests have been added or updated.
- [x] Documentation has been updated (if applicable).
- [x] I have applied neccessary labels to this PR.
- [x] I have tested this change locally and on staging.
- [x] At a functional level, it has been validated with the team/PO.
